### PR TITLE
[SASTAA] Fixes for internal/handlers/unsafe_response.go

### DIFF
--- a/internal/handlers/unsafe_response.go
+++ b/internal/handlers/unsafe_response.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 )
 
-// UnsafeEcho writes untrusted input directly to the response (vulnerable)
+// UnsafeEcho writes untrusted input directly to the response (vulnerable) but escaped for safety
 func UnsafeEcho(w http.ResponseWriter, r *http.Request) {
 	user := r.URL.Query().Get("user")
-	fmt.Fprintf(w, "Hello, %s", user)
+	fmt.Fprintf(w, "Hello, %s", html.EscapeString(user))
 }
 
 // SafeEchoEscaped escapes untrusted input before writing


### PR DESCRIPTION
## Security Findings Addressed

This pull request addresses the following security findings:

### Finding 1
- **Location**: [Line 13](https://github.com/amylraj/go-sast-vuln/blob/main/internal/handlers/unsafe_response.go#L13)
- **Issue**: A SAST finding was identified in this repository version.
- **CWEs Addressed**:
  - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
- **Remediation**: - Use 'html.EscapeString()' to safely escape HTML - Implement proper input validation and sanitization. - Some accepted sanitizers include: - go-sanitize/sanitize - microcosm-cc/bluemonday - Apply Content Security Policy (CSP) headers

## Affected Files

- [internal/handlers/unsafe_response.go](https://github.com/amylraj/go-sast-vuln/blob/main/internal/handlers/unsafe_response.go)
