### PR TITLE
[SASTAA] Fixes for internal/handlers/cookies.go

### DIFF
--- a/internal/handlers/cookies.go
+++ b/internal/handlers/cookies.go
@@ -6,7 +6,13 @@ import (
 
 // CookieMissingFlags sets cookie without HttpOnly and Secure (vulnerable)
 func CookieMissingFlags(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Set-Cookie", "session=abc123; Path=/")
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    "abc123",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+	})
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
## Security Findings Addressed

This pull request addresses the following security findings:

### Finding 1
- **Location**: [Line 9](https://github.com/amylraj/go-sast-vuln/blob/main/internal/handlers/cookies.go#L9)
- **Issue**: A SAST finding was identified in this repository version.
- **CWEs Addressed**:
  - CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
- **Remediation**: To remediate this issue, ensure that all cookies containing sensitive information or used for session management are set with the 'Secure' attribute. This ensures cookies are only transmitted over secure HTTPS connections, protecting them from interception. In Go, when setting cookies, explicitly set the Secure field to true:

```go http.SetCookie(w, &http.Cookie{ Name: "session_id", Value: "abc123", Secure: true, // Ensure the Secure flag is set HttpOnly: true, // Also consider setting HttpOnly to prevent JavaScript access }) ```

### Finding 2
- **Location**: [Line 9](https://github.com/amylraj/go-sast-vuln/blob/main/internal/handlers/cookies.go#L9)
- **Issue**: A SAST finding was identified in this repository version.
- **CWEs Addressed**:
  - CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag
- **Remediation**: To remediate this issue, ensure that the 'HttpOnly' flag is set for all cookies that contain sensitive information. This can be done by explicitly setting the 'HttpOnly' attribute to true when creating cookies. For example, in Go, when using the http.Cookie struct, set the HttpOnly field to true:

```go http.SetCookie(w, &http.Cookie{ Name: "session_id", Value: "abc123", HttpOnly: true, }) ```

When setting cookies via HTTP headers, append the 'HttpOnly' attribute to the Set-Cookie header value:

```go w.Header().Set("Set-Cookie", "session_id=abc123; HttpOnly") ```

## Affected Files

- [internal/handlers/cookies.go](https://github.com/amylraj/go-sast-vuln/blob/main/internal/handlers/cookies.go)
