### PR TITLE
[SASTAA] Fixes for internal/handlers/echo_examples.go

### DIFF
--- a/internal/handlers/echo_examples.go
+++ b/internal/handlers/echo_examples.go
@@ -49,11 +49,22 @@ func EchoSQLiSafePrepared(c echo.Context) error {
 // EchoSQLiDBVuln uses tainted input in DB query sink
 func EchoSQLiDBVuln(c echo.Context) error {
 	id := c.QueryParam("id")
-	db, _ := sql.Open("sqlite3", ":memory:")
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		return err
+	}
 	defer db.Close()
-	// vulnerable query concatenation
-	q := "SELECT * FROM users WHERE id = '" + id + "'"
-	_, _ = db.Query(q)
+	// using prepared statement to prevent SQL injection
+	stmt, err := db.Prepare("SELECT * FROM users WHERE id = ?")
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	rows, err := stmt.Query(id)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
 	return c.String(http.StatusOK, "ok")
 }
 


### PR DESCRIPTION
<h1 align="center">
  🔒 Endor Labs SAST Security Fixes
</h1>

## Summary

This PR addresses security vulnerabilities identified by SAST analysis:

### 📂 Files Updated

| File | Issues Fixed |
|------|-------------|
| `internal/handlers/echo_examples.go` | 1 |

---

## 🛡️ Security Impact

<details>
  <summary>🔍 <b>Security findings addressed in this pull request (Click to expand)</b></summary>

| Location | Issue | Rule ID | CWEs |
|----------|-------|---------|------|
| [Line 56](https://github.com/amylraj/go-sast-vuln/blob/main/internal/handlers/echo_examples.go#L56) | A SAST finding was identified in this repository version. | `go-sqli-tainted-input` | CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') |

</details>

---

### 💡 Reminders

- **Test**: Ensure your tests pass and verify this change doesn't impact your application before merging.
- **Review**: Carefully review the security fixes to understand the changes made.

---

<p align="center">
  <sub>
    Generated by <a href="https://endorlabs.com/">Endor Labs SAST Analysis</a>
  </sub>
</p>
